### PR TITLE
Craft 3.1 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+### Added
+- Added Craft 3.1 compatibility
+
 ## 1.0.1 - 2018-04-30
 ### Changed
 - Removed redundant files

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Hide Admin hides admin users from non-admin users, which is useful if you want t
 
 ## Requirements
 
-This plugin requires Craft CMS 3.0.0 or later.
+This plugin requires Craft CMS 3.1.0 or later.
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "craftcms/cms": "^3.0.0"
+        "craftcms/cms": "^3.1.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/HideAdmin.php
+++ b/src/HideAdmin.php
@@ -55,7 +55,7 @@ class HideAdmin extends Plugin
 
                         foreach ($groups as $group) {
                             $event->sources[] = [
-                                'key' => 'group:'.$group->id,
+                                'key' => 'group:'.$group->uid,
                                 'label' => Craft::t('site', $group->name),
                                 'criteria' => ['groupId' => $group->id],
                                 'hasThumbs' => true


### PR DESCRIPTION
User group source keys are now UID-based rather than ID-based.